### PR TITLE
Make use of copyImage instead of pxBuffer when creating UIImage

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -72,7 +72,7 @@ import VideoToolbox
         data.withUnsafeBytes { rawBufferPointer in
             let rawPtr = rawBufferPointer.baseAddress!
             let address = UnsafeMutableRawPointer(mutating:rawPtr)
-            guard let pxBuffer = bytesToPixelBuffer(width: imageWidth, height: imageHeight, baseAddress: address, bytesPerRow: bytes), let copyImage = pxBuffer.copy() , let cgiImage = createImage(from: pxBuffer) else {
+            guard let pxBuffer = bytesToPixelBuffer(width: imageWidth, height: imageHeight, baseAddress: address, bytesPerRow: bytes), let copyImage = pxBuffer.copy() , let cgiImage = createImage(from: copyImage) else {
                 return nil
             }
             


### PR DESCRIPTION
A tiny complement on <i>https://github.com/theamorn/flutter-stream-image/commit/42f3d8f4b872695e56c75a359ca996f7c533a40c Add deep copy pixel</i>